### PR TITLE
remove setting scan config multiple times

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,3 +1,58 @@
+---
+
+aliases:
+  # common - cache
+  - &cache_restore_git
+    restore_cache:
+      name: cache | restore git
+      keys:
+        - src-v1-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+        - src-v1-{{ arch }}-{{ .Branch }}-
+        - src-v1-{{ arch }}
+  - &cache_save_git
+    save_cache:
+      name: cache | save git
+      key: src-v1-{{ arch }}-{{ .Branch }}-{{ .Revision }}
+      paths:
+        - ".git"
+
+  - &cache_restore_bundler
+    restore_cache:
+      name: cache | restore bundle
+      key: v2-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+  - &cache_save_bundler
+    save_cache:
+      name: cache | store bundle
+      key: v2-gems-{{ arch }}-{{ .Branch }}-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
+      paths:
+        - ".bundle"
+
+  - &cache_restore_homebrew
+    restore_cache:
+      name: cache | restore homebrew
+      keys:
+        - v3-homebrew-{{ epoch }}
+        - v3-homebrew
+  - &cache_save_homebrew
+    save_cache:
+      name: cache | store homebrew
+      key: v3-homebrew-{{ epoch }}
+      paths:
+        - "/usr/local/Homebrew"
+
+  - &cache_restore_rubocop
+    restore_cache:
+      name: cache | restore rubocop
+      keys:
+        - v1-rubocop-{{ arch }}-{{ epoch }}
+        - v1-rubocop-{{ arch }}-
+  - &cache_save_rubocop
+    save_cache:
+      name: cache | store rubocop
+      key: v1-rubocop-{{ arch }}-{{ epoch }}
+      paths:
+        - "~/.cache/rubocop_cache"
+
 version: 2
 
 jobs:
@@ -10,14 +65,12 @@ jobs:
       LANG: en_US.UTF-8
     shell: /bin/bash --login -eo pipefail
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
+      - *cache_restore_homebrew
 
-      - restore_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-      - restore_cache:
-          keys:
-            - v3-homebrew-{{ epoch }}
-            - v3-homebrew
       - run:
           name: Setup Build
           command: |
@@ -27,28 +80,19 @@ jobs:
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 
-      - save_cache:
-          key: v3-homebrew-{{ epoch }}
-          paths:
-            - /usr/local/Homebrew
-      - save_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-          paths:
-            - .bundle
+      - *cache_save_homebrew
+      - *cache_save_bundler
 
       - run:
           name: Check PR Metadata
           command: bundle exec danger || echo "danger failed"
 
-      - restore_cache:
-          key: v1-{{ arch }}-rubocop
+      - *cache_restore_rubocop
 
       - run: bundle exec fastlane execute_tests
 
-      - save_cache:
-          key: v1-{{ arch }}-rubocop
-          paths:
-            - ~/.cache/rubocop_cache
+      - *cache_save_rubocop
+
       - store_test_results:
           path: ~/test-reports
       - store_artifacts:
@@ -58,7 +102,7 @@ jobs:
       - run:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
-          when: always # Run this even when tests fail
+          when: always  # Run this even when tests fail
 
   "Execute tests on macOS (Xcode 11.0.0, Ruby 2.5)":
     macos:
@@ -69,14 +113,12 @@ jobs:
       LANG: en_US.UTF-8
     shell: /bin/bash --login -eo pipefail
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
+      - *cache_restore_homebrew
 
-      - restore_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-      - restore_cache:
-          keys:
-            - v3-homebrew-{{ epoch }}
-            - v3-homebrew
       - run:
           name: Setup Build
           command: |
@@ -86,28 +128,18 @@ jobs:
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 
-      - save_cache:
-          key: v3-homebrew-{{ epoch }}
-          paths:
-            - /usr/local/Homebrew
-      - save_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-          paths:
-            - .bundle
+      - *cache_save_homebrew
+      - *cache_save_bundler
 
       - run:
           name: Check PR Metadata
           command: bundle exec danger || echo "danger failed"
 
-      - restore_cache:
-          key: v1-{{ arch }}-rubocop
+      - *cache_restore_rubocop
 
       - run: bundle exec fastlane execute_tests
 
-      - save_cache:
-          key: v1-{{ arch }}-rubocop
-          paths:
-            - ~/.cache/rubocop_cache
+      - *cache_save_rubocop
       - store_test_results:
           path: ~/test-reports
       - store_artifacts:
@@ -117,7 +149,7 @@ jobs:
       - run:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
-          when: always # Run this even when tests fail
+          when: always  # Run this even when tests fail
 
   "Execute tests on Ubuntu":
     environment:
@@ -128,33 +160,28 @@ jobs:
     docker:
       - image: fastlanetools/ci:0.1.0
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
 
-      - restore_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
       - run:
           name: Setup Build
           command: |
             mkdir -p ~/test-reports
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - save_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-          paths:
-            - .bundle
+      - *cache_save_bundler
 
       - run:
           name: Check PR Metadata
           command: bundle exec danger || echo "danger failed"
 
-      - restore_cache:
-          key: v1-{{ arch }}-rubocop
+      - *cache_restore_rubocop
 
       - run: bundle exec fastlane execute_tests
 
-      - save_cache:
-          key: v1-{{ arch }}-rubocop
-          paths:
-            - ~/.cache/rubocop_cache
+      - *cache_save_rubocop
+
       - store_test_results:
           path: ~/test-reports
       - store_artifacts:
@@ -164,7 +191,7 @@ jobs:
       - run:
           name: Post Test Results to GitHub
           command: bundle exec danger || echo "danger failed"
-          when: always # Run this even when tests fail
+          when: always  # Run this even when tests fail
 
   "Validate Fastlane.swift Generation":
     macos:
@@ -175,14 +202,12 @@ jobs:
       LANG: en_US.UTF-8
     shell: /bin/bash --login -eo pipefail
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
+      - *cache_restore_homebrew
 
-      - restore_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-      - restore_cache:
-          keys:
-            - v3-homebrew-{{ epoch }}
-            - v3-homebrew
       - run:
           name: Setup Build
           command: |
@@ -192,14 +217,8 @@ jobs:
             brew install shellcheck
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
 
-      - save_cache:
-          key: v3-homebrew-{{ epoch }}
-          paths:
-            - /usr/local/Homebrew
-      - save_cache:
-          key: v1-macos-gems-{{ checksum "Gemfile" }}-{{ checksum "fastlane.gemspec" }}
-          paths:
-            - .bundle
+      - *cache_save_homebrew
+      - *cache_save_bundler
 
       - run: bundle exec fastlane generate_swift_api
 
@@ -207,20 +226,19 @@ jobs:
     docker:
       - image: circleci/ruby:2.4
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
 
-      - restore_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
       - run:
           name: Setup Build
           command: |
             gem update --system
             gem install bundler
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - save_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
-          paths:
-            - .bundle
+
+      - *cache_save_bundler
 
       - run: bundle exec fastlane validate_docs
 
@@ -228,18 +246,17 @@ jobs:
     docker:
       - image: circleci/ruby:2.5
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
+      - *cache_restore_bundler
 
-      - restore_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
       - run:
           name: Setup Build
           command: |
             bundle check --path .bundle || bundle install --jobs=4 --retry=3 --path .bundle
-      - save_cache:
-          key: v1-ubuntu-gems-{{ checksum "Gemfile" }}
-          paths:
-            - .bundle
+
+      - *cache_save_bundler
 
       - run: bundle exec fastlane lint_source
 
@@ -251,7 +268,9 @@ jobs:
       - image: circleci/ruby:2.3
     shell: /bin/bash --login -eo pipefail
     steps:
+      - *cache_restore_git
       - checkout
+      - *cache_save_git
 
       - run:
           name: Setup Build
@@ -272,3 +291,5 @@ workflows:
       - "Validate Documentation"
       - "Lint Source Code"
       - "Execute modules load up tests"
+
+...

--- a/.github/workflows/pull-requests.yml
+++ b/.github/workflows/pull-requests.yml
@@ -1,0 +1,29 @@
+name: Processing pull requests
+on: 
+  pull_request:
+    types: [closed]
+
+jobs:   
+  communicate-on-pull-request-merged:
+    name: communicate on pull request merged
+    runs-on: ubuntu-latest    
+    steps:
+      - name: Git checkout
+        if: github.event.pull_request.merged
+        uses: actions/checkout@master
+        with:
+          ref: refs/heads/master
+      
+      - name: Communicate on PR merged
+        if: github.event.pull_request.merged
+        uses: fastlane/github-actions/communicate-on-pull-request-merged@latest
+        with:
+          repo-token: "${{ secrets.BOT_GITHUB_TOKEN }}"
+          pr-comment: "Hey @${{ github.event.pull_request.user.login }} :wave:\n\n
+            Thank you for your contribution to _fastlane_ and congrats on getting this pull request merged :tada:\n
+            The code change now lives in the `master` branch, however it wasn't released to [RubyGems](https://rubygems.org/gems/fastlane) yet.\n
+            We usually ship about once a week, and your PR will be included in the next one.\n\n
+            Please let us know if this change requires an immediate release by adding a comment here :+1:\n
+            We'll notify you once we shipped a new release with your changes :rocket:"
+          pr-label-to-add: 'status: included-in-next-release'
+          pr-label-to-remove: 'status: needs-attention'

--- a/fastlane.gemspec
+++ b/fastlane.gemspec
@@ -104,7 +104,7 @@ Gem::Specification.new do |spec|
 
   # The Google API Client gem is *not* API stable between minor versions - hence the specific version locking here.
   # If you upgrade this gem, make sure to upgrade the users of it as well.
-  spec.add_dependency('google-api-client', '>= 0.21.2', '< 0.24.0') # Google API Client to access Play Publishing API
+  spec.add_dependency('google-api-client', '>= 0.29.2', '< 0.37.0') # Google API Client to access Play Publishing API
   spec.add_dependency('google-cloud-storage', '>= 1.15.0', '< 2.0.0') # Access Google Cloud Storage for match
 
   spec.add_dependency('emoji_regex', '>= 0.1', '< 2.0') # Used to scan for Emoji in the changelog

--- a/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
+++ b/fastlane/lib/fastlane/actions/docs/upload_to_app_store.md.erb
@@ -706,6 +706,16 @@ DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS="-t DAV" fastlane deliver
 ## HTTP Proxy
 iTunes Transporter is a Java application bundled with Xcode. In addition to utilizing the `DELIVER_ITMSTRANSPORTER_ADDITIONAL_UPLOAD_PARAMETERS="-t DAV"`, you need to configure the transporter application to use the proxy independently from the system proxy or any environment proxy settings. You can find the configuration file within Xcode:
 
+**for Xcode11 and later**
+
+```no-highlight
+TOOLS_PATH=$( xcode-select -p )
+REL_PATH='../SharedFrameworks/ContentDeliveryServices.framework/Versions/A/itms/java/lib/net.properties'
+echo "$TOOLS_PATH/$REL_PATH"
+```
+
+**for Xcode10 or earlier**
+
 ```no-highlight
 TOOLS_PATH=$( xcode-select -p )
 REL_PATH='../Applications/Application Loader.app/Contents/itms/java/lib/net.properties'

--- a/fastlane/lib/fastlane/actions/last_git_tag.rb
+++ b/fastlane/lib/fastlane/actions/last_git_tag.rb
@@ -2,7 +2,7 @@ module Fastlane
   module Actions
     class LastGitTagAction < Action
       def self.run(params)
-        Actions.last_git_tag_name
+        Actions.last_git_tag_name(true, params[:pattern])
       end
 
       #####################################################
@@ -14,7 +14,12 @@ module Fastlane
       end
 
       def self.available_options
-        []
+        [
+          FastlaneCore::ConfigItem.new(key: :pattern,
+                                       description: "Pattern to filter tags when looking for last one. Limit tags to ones matching given shell glob. If pattern lacks ?, *, or [, * at the end is implied",
+                                       default_value: nil,
+                                       optional: true)
+        ]
       end
 
       def self.output
@@ -26,7 +31,7 @@ module Fastlane
       end
 
       def self.authors
-        ["KrauseFx"]
+        ["KrauseFx", "wedkarz"]
       end
 
       def self.is_supported?(platform)
@@ -34,12 +39,16 @@ module Fastlane
       end
 
       def self.details
-        "If you are using this action on a **shallow clone**, *the default with some CI systems like Bamboo*, you need to ensure that you have also pulled all the git tags appropriately. Assuming your git repo has the correct remote set you can issue `sh('git fetch --tags')`."
+        [
+          "If you are using this action on a **shallow clone**, *the default with some CI systems like Bamboo*, you need to ensure that you have also pulled all the git tags appropriately. Assuming your git repo has the correct remote set you can issue `sh('git fetch --tags')`.",
+          "Pattern parameter allows you to filter to a subset of tags."
+        ].join("\n")
       end
 
       def self.example_code
         [
-          'last_git_tag'
+          'last_git_tag',
+          'last_git_tag(pattern: "release/v1.0/")'
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -10,17 +10,10 @@ module Fastlane
     class RunTestsAction < Action
       def self.run(values)
         require 'scan'
-        plist_files_before = []
+        manager = Scan::Manager.new
 
         begin
-          destination = values[:destination] # save destination value which can be later overridden
-          Scan.config = values if values[:derived_data_path].to_s.empty? # we set this here to auto-detect missing values, which we need later on
-          unless values[:derived_data_path].to_s.empty?
-            plist_files_before = test_summary_filenames(values[:derived_data_path])
-          end
-
-          values[:destination] = destination # restore destination value
-          Scan::Manager.new.work(values)
+          manager.work(values)
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
@@ -37,8 +30,10 @@ module Fastlane
           end
         ensure
           unless values[:derived_data_path].to_s.empty?
+            plist_files_before = manager.plist_files_before || []
+
             Actions.lane_context[SharedValues::SCAN_DERIVED_DATA_PATH] = values[:derived_data_path]
-            plist_files_after = test_summary_filenames(values[:derived_data_path])
+            plist_files_after = manager.test_summary_filenames(values[:derived_data_path])
             all_test_summaries = (plist_files_after - plist_files_before)
             Actions.lane_context[SharedValues::SCAN_GENERATED_PLIST_FILES] = all_test_summaries
             Actions.lane_context[SharedValues::SCAN_GENERATED_PLIST_FILE] = all_test_summaries.last
@@ -84,18 +79,6 @@ module Fastlane
       end
 
       private_class_method
-
-      def self.test_summary_filenames(derived_data_path)
-        files = []
-
-        # Xcode < 10
-        files += Dir["#{derived_data_path}/**/Logs/Test/*TestSummaries.plist"]
-
-        # Xcode 10
-        files += Dir["#{derived_data_path}/**/Logs/Test/*.xcresult/TestSummaries.plist"]
-
-        return files
-      end
 
       def self.example_code
         [

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -66,17 +66,7 @@ module Fastlane
                                        env_name: "SCAN_FAIL_BUILD",
                                        description: "Should this step stop the build if the tests fail? Set this to false if you're using trainer",
                                        is_string: false,
-                                       default_value: true),
-          FastlaneCore::ConfigItem.new(key: :app_name,
-                                       env_name: "SCAN_APP_NAME",
-                                       optional: true,
-                                       description: "Name of the target which is being build or tested",
-                                       is_string: true),
-          FastlaneCore::ConfigItem.new(key: :deployment_target_version,
-                                       env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
-                                       optional: true,
-                                       description: "Target version of the app being build or tested. Used to filter out simulator version",
-                                       is_string: true)
+                                       default_value: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -14,7 +14,6 @@ module Fastlane
 
         begin
           destination = values[:destination] # save destination value which can be later overridden
-          Scan.config = values # we set this here to auto-detect missing values, which we need later on
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = test_summary_filenames(values[:derived_data_path])
           end

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -14,12 +14,13 @@ module Fastlane
 
         begin
           destination = values[:destination] # save destination value which can be later overridden
+          Scan.config = values if values[:derived_data_path].to_s.empty? # we set this here to auto-detect missing values, which we need later on
           unless values[:derived_data_path].to_s.empty?
             plist_files_before = test_summary_filenames(values[:derived_data_path])
           end
 
           values[:destination] = destination # restore destination value
-          Scan::Manager.new.work(values)
+          Scan::Manager.new.work(values) 
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path
@@ -65,7 +66,17 @@ module Fastlane
                                        env_name: "SCAN_FAIL_BUILD",
                                        description: "Should this step stop the build if the tests fail? Set this to false if you're using trainer",
                                        is_string: false,
-                                       default_value: true)
+                                       default_value: true),
+          FastlaneCore::ConfigItem.new(key: :app_name,
+                                       env_name: "SCAN_APP_NAME",
+                                       optional: true,
+                                       description: "Name of the target which is being build or tested",
+                                       is_string: true),
+          FastlaneCore::ConfigItem.new(key: :deployment_target_version,
+                                       env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
+                                       optional: true,
+                                       description: "Target version of the app being build or tested. Used to filter out simulator version",
+                                       is_string: true)
         ]
       end
 

--- a/fastlane/lib/fastlane/actions/run_tests.rb
+++ b/fastlane/lib/fastlane/actions/run_tests.rb
@@ -20,7 +20,7 @@ module Fastlane
           end
 
           values[:destination] = destination # restore destination value
-          Scan::Manager.new.work(values) 
+          Scan::Manager.new.work(values)
 
           zip_build_products_path = Scan.cache[:zip_build_products_path]
           Actions.lane_context[SharedValues::SCAN_ZIP_BUILD_PRODUCTS_PATH] = zip_build_products_path if zip_build_products_path

--- a/fastlane/lib/fastlane/actions/setup_ci.rb
+++ b/fastlane/lib/fastlane/actions/setup_ci.rb
@@ -37,7 +37,8 @@ module Fastlane
           unlock: true,
           timeout: 3600,
           lock_when_sleeps: true,
-          password: ""
+          password: "",
+          add_to_search_list: true
         )
 
         UI.message("Enabling match readonly mode.")

--- a/fastlane/lib/fastlane/actions/upload_to_play_store_internal_app_sharing.rb
+++ b/fastlane/lib/fastlane/actions/upload_to_play_store_internal_app_sharing.rb
@@ -1,0 +1,78 @@
+module Fastlane
+  module Actions
+    class UploadToPlayStoreInternalAppSharingAction < Action
+      def self.run(params)
+        require 'supply'
+
+        # If no APK params were provided, try to fill in the values from lane context, preferring
+        # the multiple APKs over the single APK if set.
+        if params[:apk_paths].nil? && params[:apk].nil?
+          all_apk_paths = Actions.lane_context[SharedValues::GRADLE_ALL_APK_OUTPUT_PATHS] || []
+          if all_apk_paths.size > 1
+            params[:apk_paths] = all_apk_paths
+          else
+            params[:apk] = Actions.lane_context[SharedValues::GRADLE_APK_OUTPUT_PATH]
+          end
+        end
+
+        # If no AAB param was provided, try to fill in the value from lane context.
+        # First GRADLE_ALL_AAB_OUTPUT_PATHS if only one
+        # Else from GRADLE_AAB_OUTPUT_PATH
+        if params[:aab].nil?
+          all_aab_paths = Actions.lane_context[SharedValues::GRADLE_ALL_AAB_OUTPUT_PATHS] || []
+          if all_aab_paths.count == 1
+            params[:aab] = all_aab_paths.first
+          else
+            params[:aab] = Actions.lane_context[SharedValues::GRADLE_AAB_OUTPUT_PATH]
+          end
+        end
+
+        Supply.config = params # we already have the finished config
+
+        Supply::Uploader.new.perform_upload_to_internal_app_sharing
+      end
+
+      #####################################################
+      # @!group Documentation
+      #####################################################
+
+      def self.description
+        "Upload binaries to Google Play Internal App Sharing (via _supply_)"
+      end
+
+      def self.details
+        "More information: https://docs.fastlane.tools/actions/upload_to_play_store_internal_app_sharing/"
+      end
+
+      def self.available_options
+        require 'supply'
+        require 'supply/options'
+        options = Supply::Options.available_options.clone
+
+        # remove all the unnecessary (for this action) options
+        options_to_keep = [:package_name, :apk, :apk_paths, :aab, :aab_paths, :json_key, :json_key_data, :root_url, :timeout]
+        options.delete_if { |option| options_to_keep.include?(option.key) == false }
+      end
+
+      def self.return_value
+        "Returns a string containing the download URL for the uploaded APK/AAB (or array of strings if multiple were uploaded)."
+      end
+
+      def self.authors
+        ["andrewhavens"]
+      end
+
+      def self.is_supported?(platform)
+        platform == :android
+      end
+
+      def self.example_code
+        ["upload_to_play_store_internal_app_sharing"]
+      end
+
+      def self.category
+        :production
+      end
+    end
+  end
+end

--- a/fastlane/spec/actions_specs/last_git_tag_spec.rb
+++ b/fastlane/spec/actions_specs/last_git_tag_spec.rb
@@ -10,6 +10,17 @@ describe Fastlane do
         describe = %W(git describe --tags #{tag_name}).shelljoin
         expect(result).to eq(describe)
       end
+
+      it "Returns nothing for jibberish tag pattern match" do
+        tag_pattern = "jibberish"
+        result = Fastlane::FastFile.new.parse("lane :test do
+          last_git_tag(pattern: \"#{tag_pattern}\")
+        end").runner.execute(:test)
+
+        tag_name = %W(git rev-list --tags=#{tag_pattern} --max-count=1).shelljoin
+        describe = %W(git describe --tags #{tag_name}).shelljoin
+        expect(result).to eq(describe)
+      end
     end
   end
 end

--- a/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
+++ b/fastlane/spec/actions_specs/setup_circle_ci_spec.rb
@@ -38,7 +38,8 @@ describe Fastlane do
             unlock: true,
             timeout: 3600,
             lock_when_sleeps: true,
-            password: ""
+            password: "",
+            add_to_search_list: true
           }
         )
 

--- a/fastlane/spec/actions_specs/setup_travis_spec.rb
+++ b/fastlane/spec/actions_specs/setup_travis_spec.rb
@@ -38,7 +38,8 @@ describe Fastlane do
             unlock: true,
             timeout: 3600,
             lock_when_sleeps: true,
-            password: ""
+            password: "",
+            add_to_search_list: true
           }
         )
 

--- a/fastlane/spec/unused_options_spec.rb
+++ b/fastlane/spec/unused_options_spec.rb
@@ -58,6 +58,7 @@ describe Fastlane do
           sync_code_signing
           upload_to_app_store
           upload_to_play_store
+          upload_to_play_store_internal_app_sharing
           upload_to_testflight
           puts
           println

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -108,7 +108,7 @@ module Scan
     def self.detect_simulator(devices, requested_os_type, deployment_target_key, default_device_name, simulator_type_descriptor)
       require 'set'
 
-      deployment_target_version = Scan.project.build_settings(key: deployment_target_key) || '0'
+      deployment_target_version = get_deployment_target_version(deployment_target_key)
 
       simulators = filter_simulators(
         FastlaneCore::DeviceManager.simulators(requested_os_type).tap do |array|
@@ -215,5 +215,11 @@ module Scan
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
+    
+    #get deployment target version
+    def self.get_deployment_target_version(deployment_target_key)
+       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
+    end
+    
   end
 end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -216,9 +216,9 @@ module Scan
       end
     end
     
-    #get deployment target version
+    # get deployment target version
     def self.get_deployment_target_version(deployment_target_key)
-       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
+      Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
     end
     
   end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -215,11 +215,11 @@ module Scan
         Scan.config[:destination] = min_xcode8? ? ["platform=macOS"] : ["platform=OS X"]
       end
     end
-    
+
     # get deployment target version
     def self.get_deployment_target_version(deployment_target_key)
       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
     end
-    
+
   end
 end

--- a/scan/lib/scan/detect_values.rb
+++ b/scan/lib/scan/detect_values.rb
@@ -220,6 +220,5 @@ module Scan
     def self.get_deployment_target_version(deployment_target_key)
       Scan.config[:deployment_target_version] || Scan.project.build_settings(key: deployment_target_key) || '0'
     end
-
   end
 end

--- a/scan/lib/scan/manager.rb
+++ b/scan/lib/scan/manager.rb
@@ -4,8 +4,13 @@ require_relative 'runner'
 
 module Scan
   class Manager
+    attr_accessor :plist_files_before
+
     def work(options)
-      Scan.config = options
+      Scan.config = options # we set this here to auto-detect missing values, which we need later on
+      unless options[:derived_data_path].to_s.empty?
+        self.plist_files_before = test_summary_filenames(Scan.config[:derived_data_path])
+      end
 
       # Also print out the path to the used Xcode installation
       # We go 2 folders up, to not show "Contents/Developer/"
@@ -16,6 +21,18 @@ module Scan
                                              title: "Summary for scan #{Fastlane::VERSION}")
 
       return Runner.new.run
+    end
+
+    def test_summary_filenames(derived_data_path)
+      files = []
+
+      # Xcode < 10
+      files += Dir["#{derived_data_path}/**/Logs/Test/*TestSummaries.plist"]
+
+      # Xcode 10
+      files += Dir["#{derived_data_path}/**/Logs/Test/*.xcresult/TestSummaries.plist"]
+
+      return files
     end
   end
 end

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -310,7 +310,7 @@ module Scan
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
-        
+
         # build settings
         FastlaneCore::ConfigItem.new(key: :app_name,
                                     env_name: "SCAN_APP_NAME",
@@ -322,7 +322,7 @@ module Scan
                                     optional: true,
                                     description: "Target version of the app being build or tested. Used to filter out simulator version",
                                     is_string: true),
-        
+
         # slack
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -311,17 +311,17 @@ module Scan
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
         
-        #build settings
+        # build settings
         FastlaneCore::ConfigItem.new(key: :app_name,
-               env_name: "SCAN_APP_NAME",
-               optional: true,
-               description: "Name of the target which is being build or tested",
-               is_string: true),
+                                    env_name: "SCAN_APP_NAME",
+                                    optional: true,
+                                    description: "Name of the target which is being build or tested",
+                                    is_string: true),
         FastlaneCore::ConfigItem.new(key: :deployment_target_version,
-              env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
-              optional: true,
-              description: "Target version of the app being build or tested. Used to filter out simulator version",
-              is_string: true),
+                                    env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
+                                    optional: true,
+                                    description: "Target version of the app being build or tested. Used to filter out simulator version",
+                                    is_string: true),
         
         # slack
         FastlaneCore::ConfigItem.new(key: :slack_url,

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -315,7 +315,7 @@ module Scan
         FastlaneCore::ConfigItem.new(key: :app_name,
                                     env_name: "SCAN_APP_NAME",
                                     optional: true,
-                                    description: "Name of the target which is being build or tested",
+                                    description: "App name to use in slack message and logfile name",
                                     is_string: true),
         FastlaneCore::ConfigItem.new(key: :deployment_target_version,
                                     env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",

--- a/scan/lib/scan/options.rb
+++ b/scan/lib/scan/options.rb
@@ -310,7 +310,19 @@ module Scan
                                      verify_block: proc do |value|
                                        UI.user_error!("File not found at path '#{File.expand_path(value)}'") unless File.exist?(value)
                                      end),
-
+        
+        #build settings
+        FastlaneCore::ConfigItem.new(key: :app_name,
+               env_name: "SCAN_APP_NAME",
+               optional: true,
+               description: "Name of the target which is being build or tested",
+               is_string: true),
+        FastlaneCore::ConfigItem.new(key: :deployment_target_version,
+              env_name: "SCAN_DEPLOYMENT_TARGET_VERSION",
+              optional: true,
+              description: "Target version of the app being build or tested. Used to filter out simulator version",
+              is_string: true),
+        
         # slack
         FastlaneCore::ConfigItem.new(key: :slack_url,
                                      short_option: "-i",

--- a/scan/lib/scan/slack_poster.rb
+++ b/scan/lib/scan/slack_poster.rb
@@ -44,7 +44,7 @@ module Scan
       end
 
       Fastlane::Actions::SlackAction.run({
-        message: "#{Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
+        message: "#{Scan.config[:app_name] || Scan.project.app_name} Tests:\n#{Scan.config[:slack_message]}",
         channel: channel,
         slack_url: Scan.config[:slack_url].to_s,
         success: results[:build_errors].to_i == 0 && results[:failures].to_i == 0,

--- a/scan/lib/scan/test_command_generator.rb
+++ b/scan/lib/scan/test_command_generator.rb
@@ -120,7 +120,7 @@ module Scan
 
     # Store the raw file
     def xcodebuild_log_path
-      file_name = "#{Scan.project.app_name}-#{Scan.config[:scheme]}.log"
+      file_name = "#{Scan.config[:app_name] || Scan.project.app_name}-#{Scan.config[:scheme]}.log"
       containing = File.expand_path(Scan.config[:buildlog_path])
       FileUtils.mkdir_p(containing)
 

--- a/supply/lib/supply/client.rb
+++ b/supply/lib/supply/client.rb
@@ -310,6 +310,19 @@ module Supply
       return result_upload.version_code
     end
 
+    def upload_apk_to_internal_app_sharing(package_name, path_to_apk)
+      # NOTE: This Google API is a little different. It doesn't require an active edit.
+      result_upload = call_google_api do
+        client.uploadapk_internalappsharingartifact(
+          package_name,
+          upload_source: path_to_apk,
+          content_type: "application/octet-stream"
+        )
+      end
+
+      return result_upload.download_url
+    end
+
     def upload_mapping(path_to_mapping, apk_version_code)
       ensure_active_edit!
 
@@ -338,6 +351,19 @@ module Supply
       end
 
       return result_upload.version_code
+    end
+
+    def upload_bundle_to_internal_app_sharing(package_name, path_to_aab)
+      # NOTE: This Google API is a little different. It doesn't require an active edit.
+      result_upload = call_google_api do
+        client.uploadbundle_internalappsharingartifact(
+          package_name,
+          upload_source: path_to_aab,
+          content_type: "application/octet-stream"
+        )
+      end
+
+      return result_upload.download_url
     end
 
     # Get a list of all tracks - returns the list

--- a/supply/lib/supply/uploader.rb
+++ b/supply/lib/supply/uploader.rb
@@ -42,6 +42,34 @@ module Supply
       end
     end
 
+    def perform_upload_to_internal_app_sharing
+      download_urls = []
+
+      package_name = Supply.config[:package_name]
+
+      apk_paths = [Supply.config[:apk]] unless (apk_paths = Supply.config[:apk_paths])
+      apk_paths.compact!
+      apk_paths.each do |apk_path|
+        download_url = client.upload_apk_to_internal_app_sharing(package_name, apk_path)
+        download_urls << download_url
+        UI.success("Successfully uploaded APK to Internal App Sharing URL: #{download_url}")
+      end
+
+      aab_paths = [Supply.config[:aab]] unless (aab_paths = Supply.config[:aab_paths])
+      aab_paths.compact!
+      aab_paths.each do |aab_path|
+        download_url = client.upload_bundle_to_internal_app_sharing(package_name, aab_path)
+        download_urls << download_url
+        UI.success("Successfully uploaded AAB to Internal App Sharing URL: #{download_url}")
+      end
+
+      if download_urls.count == 1
+        return download_urls.first
+      else
+        return download_urls
+      end
+    end
+
     def perform_upload_meta(version_codes)
       if (!Supply.config[:skip_upload_metadata] || !Supply.config[:skip_upload_images] || !Supply.config[:skip_upload_changelogs] || !Supply.config[:skip_upload_screenshots]) && metadata_path
         # Use version code from config if version codes is empty and no nil or empty string

--- a/supply/spec/client_spec.rb
+++ b/supply/spec/client_spec.rb
@@ -53,6 +53,8 @@ describe Supply do
         expect(subject.class.method_defined?(:upload_edit_image)).to eq(true)
         expect(subject.class.method_defined?(:deleteall_edit_image)).to eq(true)
         expect(subject.class.method_defined?(:upload_edit_expansionfile)).to eq(true)
+        expect(subject.class.method_defined?(:uploadapk_internalappsharingartifact)).to eq(true)
+        expect(subject.class.method_defined?(:uploadbundle_internalappsharingartifact)).to eq(true)
       end
     end
   end


### PR DESCRIPTION
### Checklist
- [x] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [x] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [x] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [x] I've updated the documentation if necessary.

### Motivation and Context
Whenever scan or run_tests is used in Fastfile it executes
xcodebuild showbuildsettings two times with same parameters which increases overall build time

### Description
Scan.config is initialized when manager is called here which does the job of using build settings for the parameters from scheme.

I have tested this change with project i am working on where run_tests is 27 times for around 14 schemes in total without any issue.

### Testing Steps
scan or run_tests actions with required parameters
